### PR TITLE
Use existing pressure plate implementation

### DIFF
--- a/src/main/java/net/darktree/redbits/blocks/ComplexPressurePlateBlock.java
+++ b/src/main/java/net/darktree/redbits/blocks/ComplexPressurePlateBlock.java
@@ -1,16 +1,9 @@
 package net.darktree.redbits.blocks;
 
-import net.minecraft.block.AbstractPressurePlateBlock;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
+import net.minecraft.block.PressurePlateBlock;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.state.StateManager;
-import net.minecraft.state.property.BooleanProperty;
-import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
@@ -18,33 +11,20 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldAccess;
 
 import java.util.List;
 
-public class ComplexPressurePlateBlock extends AbstractPressurePlateBlock {
+public class ComplexPressurePlateBlock extends PressurePlateBlock {
 
     public interface CollisionCondition {
         List<Entity> call( World world, Box box );
     }
 
-    public static final BooleanProperty POWERED = Properties.POWERED;
     private final CollisionCondition collisionCondition;
 
     public ComplexPressurePlateBlock(CollisionCondition condition, Settings settings) {
-        super(settings);
+        super(ActivationRule.EVERYTHING, settings);
         this.collisionCondition = condition;
-        this.setDefaultState(this.stateManager.getDefaultState().with(POWERED, false));
-    }
-
-    @Override
-    protected void playPressSound(WorldAccess world, BlockPos pos) {
-        world.playSound(null, pos, SoundEvents.BLOCK_STONE_PRESSURE_PLATE_CLICK_ON, SoundCategory.BLOCKS, 0.3F, 0.6F);
-    }
-
-    @Override
-    protected void playDepressSound(WorldAccess world, BlockPos pos) {
-        world.playSound(null, pos, SoundEvents.BLOCK_STONE_PRESSURE_PLATE_CLICK_OFF, SoundCategory.BLOCKS, 0.3F, 0.5F);
     }
 
     @Override
@@ -58,21 +38,6 @@ public class ComplexPressurePlateBlock extends AbstractPressurePlateBlock {
         }
 
         return 0;
-    }
-
-    @Override
-    protected int getRedstoneOutput(BlockState state) {
-        return state.get(POWERED) ? 15 : 0;
-    }
-
-    @Override
-    protected BlockState setRedstoneOutput(BlockState state, int rsOut) {
-        return state.with(POWERED, rsOut > 0);
-    }
-
-    @Override
-    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        builder.add(POWERED);
     }
 
     @Override


### PR DESCRIPTION
This allows any third-party callers in the world to safely assume your pressure plate has the `POWERED` property and reduces duplication of code that already exists for you to utilize.