### PR TITLE
Add DashLoader support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,15 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+repositories {
+	maven {
+		url "https://oskarstrom.net/maven"
+		content {
+			includeGroup "net.oskarstrom"
+		}
+	}
+}
+
 dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -18,6 +27,11 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+modImplementation ('net.oskarstrom:DashLoader:2.1-dev4') {
+	exclude group: 'net.fabricmc.fabric-api'
+}
+
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/net/darktree/redbits/dashloader/DashColorProperty.java
+++ b/src/main/java/net/darktree/redbits/dashloader/DashColorProperty.java
@@ -1,0 +1,30 @@
+package net.darktree.redbits.dashloader;
+
+import io.activej.serializer.annotations.Deserialize;
+import io.activej.serializer.annotations.Serialize;
+import net.darktree.redbits.utils.ColorProperty;
+import net.oskarstrom.dashloader.DashRegistry;
+import net.oskarstrom.dashloader.api.annotation.DashConstructor;
+import net.oskarstrom.dashloader.api.annotation.DashObject;
+import net.oskarstrom.dashloader.api.enums.ConstructorMode;
+import net.oskarstrom.dashloader.blockstate.property.DashProperty;
+
+@DashObject(ColorProperty.class)
+public class DashColorProperty implements DashProperty {
+    @Serialize(order = 0)
+    public final String name;
+
+    public DashColorProperty(@Deserialize("name") String name) {
+        this.name = name;
+    }
+
+    @DashConstructor(ConstructorMode.OBJECT)
+    public DashColorProperty(ColorProperty colorProperty) {
+        name = colorProperty.getName();
+    }
+
+    @Override
+    public ColorProperty toUndash(DashRegistry registry) {
+        return ColorProperty.of(name);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,11 @@
   "authors": [
     "magistermaks"
   ],
+  "custom": {
+    "dashloader:customobject": [
+      "net.darktree.redbits.dashloader.DashColorProperty"
+    ]
+  },
   "contributors": [
     "WarAndroid",
     "ChloeDawn"


### PR DESCRIPTION
This PR adds DashLoader support through our API, The API is designed not to require DashLoader as a dependency. 